### PR TITLE
Draw x bitmap

### DIFF
--- a/LightLCD.cpp
+++ b/LightLCD.cpp
@@ -145,6 +145,31 @@ uint8_t LightLCD::drawChar(uint8_t x, uint8_t y, uint8_t c, uint8_t color, uint8
     return (len + 1) * size;
 }
 
+/* Draw XBitMap Files (*.xbm), exported from GIMP,
+ * Uses PROGMEM array directly from *.xbm as this:
+ * 
+ *  const static uint8_t image[] PROGMEM = { ... };
+ * 
+*/
+void LightLCD::drawXBitmap(uint8_t x, uint8_t y,
+                 const uint8_t *bitmap, uint8_t width, uint8_t height,
+                 uint8_t color, uint8_t transparentBg) {
+
+    int16_t i, j, byteWidth = (width + 7) / 8;
+
+    for(j=0; j<height; j++) {
+        for(i=0; i<width; i++ ) {
+            if(pgm_read_byte(bitmap + j * byteWidth + i / 8) & (1 << (i % 8))) {
+                // draw foreground
+                drawPixel(x+i, y+j, color);
+            } else if (!transparentBg) {
+                // optionaly draw background (default no)
+                drawPixel(x+i, y+j, !color);
+            }
+        }
+    }
+}
+
 size_t LightLCD::write(uint8_t c) {
     if (c == '\n') {
         cursor_y += text_prop.size * 8;

--- a/LightLCD.h
+++ b/LightLCD.h
@@ -38,8 +38,8 @@ class LightLCD : public Print {
         void    drawRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t color);
         void    fillRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t color);
 
-
         uint8_t drawChar(uint8_t x, uint8_t y, uint8_t c, uint8_t color = 1, uint8_t transparentBg = 1, uint8_t size = 1);
+        void    drawXBitmap(uint8_t x, uint8_t y, const uint8_t *bitmap, uint8_t width, uint8_t height, uint8_t color, uint8_t transparentBg=1);
 
         uint8_t getCursorX();
         uint8_t getCursorY();

--- a/examples/ssd1306_drawXBitmap/ssd1306_drawXBitmap.ino
+++ b/examples/ssd1306_drawXBitmap/ssd1306_drawXBitmap.ino
@@ -1,0 +1,39 @@
+
+#include <Wire.h>
+#include <LightLCD.h>
+#include <LightSSD1306.h>
+
+LightSSD1306 lcd = LightSSD1306();
+
+// XBitmap array
+const static uint8_t xImage[] PROGMEM = {
+   0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x04, 0x41, 0x00, 0x08, 0x20, 0x00,
+   0x80, 0x03, 0x00, 0xe0, 0x0e, 0x00, 0x20, 0x08, 0x00, 0x30, 0x18, 0x00,
+   0x17, 0xd0, 0x01, 0x30, 0x18, 0x00, 0x20, 0x08, 0x00, 0xe0, 0x0e, 0x00,
+   0x80, 0x03, 0x00, 0x08, 0x20, 0x00, 0x04, 0x41, 0x00, 0x00, 0x01, 0x00,
+   0x00, 0x01, 0x00 }; // 17x17px
+
+void setup() {
+    //Serial.begin(115200);
+    lcd.begin();
+}
+
+void loop() {
+    uint8_t x, y;
+    // image width, height
+    uint8_t w = 17, h = 17;
+    
+    // calculate center position
+    x = lcd.width()/2 - w/2;
+    y = lcd.height()/2 - h/2;
+    
+    // draw xImage with white
+    lcd.drawXBitmap(x, y, xImage, w, h, 1);
+    lcd.update();
+    delay(1000);
+
+    // draw xImage with black (clear)
+    lcd.drawXBitmap(x, y, xImage, w, h, 0);
+    lcd.update();
+    delay(1000);
+}


### PR DESCRIPTION
I implemented the drawXBitmap function, basically taken from Adafruit's GFX, but enhanced with (optionally) drawing the background too, to allow redraw different icons on the same place. I created example usage too.

I add it to the LightLCD class, because i think, that i must work on the PCD8544 driver too, but i have not tested it, then it needs test before merge.

The usage is simple. Create B/W image and export it as [XBM](https://en.wikipedia.org/wiki/X_BitMap) (e.g. with GIMP) and edit the array to use PROGMEM e.g.:

```
const static uint8_t xImage[] PROGMEM = { .. }
```

Then use as simple as:

```
...
lcd.drawXBitmap(posX, posY, xImage, width, height, 1)
```

or to draw background too, 

```
...
lcd.drawXBitmap(posX, posY, xImage, width, height, 1, 0)
```
